### PR TITLE
Fix/local kroki service

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,6 +16,23 @@ jobs:
     permissions:
       contents: write # Required to push to the gh-pages branch
 
+    services:
+      mermaid:
+        image: yuzutech/kroki-mermaid:latest
+        ports:
+          - 8002:8002
+      kroki:
+        image: yuzutech/kroki:latest
+        env:
+          KROKI_MERMAID_HOST: mermaid
+        ports:
+          - 8000:8000
+        options: >-
+          --health-cmd "curl -f http://localhost:8000/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout playbook source
         uses: actions/checkout@v5

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -44,6 +44,7 @@ asciidoc:
     - asciidoctor-kroki
   attributes:
     kroki-fetch-diagram: true
+    kroki-server-url: http://localhost:8000
 
 output:
   dir: build/site  # Generated site output directory


### PR DESCRIPTION
 Problem: Documentation build fails with 403/503 errors when fetching diagrams from kroki.io

  Solution: Run Kroki as GitHub Actions service containers
  - Added yuzutech/kroki (main gateway) + yuzutech/kroki-mermaid (companion)
  - Configured kroki-server-url: http://localhost:8000 in playbook
  - Eliminates external dependency on kroki.io
